### PR TITLE
Fixed Windows Paths

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -67,8 +67,8 @@ Release Notes
 
     **🐛 Bug-Fixes**
 
-    *
-    *
+    * Fixed a typo in the PyPI badges in README.md
+    * Fixed an issue with paths under Windows. ``r"\"`` and ``"\\"`` are now working as expected.
 
     **⚠️ Deprecation**
 

--- a/officeextractor/main.py
+++ b/officeextractor/main.py
@@ -74,11 +74,12 @@ def extract(
         src = [src]
 
     for file_name in src:
-        check_valid_file(file_name)  # Check if the file is valid
+        file_name_path = Path(file_name)
+        check_valid_file(file_name_path)  # Check if the file is valid
         # Create subfolder Path object
-        output_folder = Path.joinpath(dest_path, file_name.split("/")[-1])
+        output_folder = Path.joinpath(dest_path, file_name_path.name)
         # Do the actual extraction
-        with ZipFile(file_name, "r") as zip_file:
+        with ZipFile(file_name_path, "r") as zip_file:
             media_list = get_media_list(zip_file=zip_file)
             file_type_count = extract_media(
                 media_list=media_list, zip_file=zip_file, output_folder=output_folder
@@ -87,18 +88,18 @@ def extract(
         if log:  # Print short summary, if log==True
             amount_files = sum(i[1] for i in file_type_count)
             if amount_files == 0:
-                print(f"\nNo media files found in {file_name}.")
+                print(f"\nNo media files found in {file_name_path}.")
             elif amount_files == 1:
-                print(f"\n1 media file extracted from {file_name}:")
+                print(f"\n1 media file extracted from {file_name_path}:")
             else:
-                print(f"\n{amount_files} media files extracted from {file_name}:")
+                print(f"\n{amount_files} media files extracted from {file_name_path}:")
 
             # Print amount of file types
             for i in file_type_count:
                 print(f"- {i[1]} {i[0]}")
 
 
-def check_valid_file(file_name: str) -> None:
+def check_valid_file(file_name: Path) -> None:
     """Check if file_name is a valid file.
 
     It is valid, if it is not a Office 2003 file, if it is in the list of supported file
@@ -106,14 +107,14 @@ def check_valid_file(file_name: str) -> None:
 
     Parameters
     ----------
-    file_name : str
+    file_name : Path
 
     Returns
     -------
     None
     """
 
-    file_type = file_name.split(".")[-1]
+    file_type = file_name.suffix.split(".")[-1]
 
     if file_type in OFFICE_2003_FILETYPES:
         raise FileTypeError(

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -18,20 +18,20 @@ from officeextractor.exceptions import FileTypeError, NotAValidFileError
 class TestCheckValidFile(TestCase):
     def test_Office_2003_file_type(self):
         with self.assertRaises(FileTypeError):
-            check_valid_file(file_name="my/folder/Test.doc")
+            check_valid_file(file_name=Path("my/folder/Test.doc"))
 
     def test_unsupported_file_type(self):
         with self.assertRaises(FileTypeError):
-            check_valid_file(file_name="my/folder/Test.abcdefg")
+            check_valid_file(file_name=Path("my/folder/Test.abcdefg"))
 
     @patch("officeextractor.main.zipfile.is_zipfile", return_value=False)
     def test_corrupted_zip_file(self, mock_zip_file):
         with self.assertRaises(NotAValidFileError):
-            check_valid_file(file_name="my/folder/Corrupt_File.docx")
+            check_valid_file(file_name=Path("my/folder/Corrupt_File.docx"))
 
     @patch("officeextractor.main.zipfile.is_zipfile", return_value=True)
     def test_working_file(self, mock_zip_file):
-        self.assertIsNone(check_valid_file(file_name="my/folder/Valid_File.docx"))
+        self.assertIsNone(check_valid_file(file_name=Path("my/folder/Valid_File.docx")))
 
 
 @patch("officeextractor.main.Path.exists")
@@ -157,9 +157,11 @@ class TestExtract(TestCase):
         mock_print,
     ):
         src = [
-            "my/folder/Test.docx",
-            "my/other/folder/Test.xlsx",
-            "Test.pptx",
+            "some/folder/Test.docx",
+            "some/other/folder/Test.xlsx",
+            "Test.pptx",  # without folder
+            r"some\other\folder2\Test2.xlsx",  # backward slash
+            "some\\other\\folder3\\Test3.xlsx",  # double backward slash
         ]
         dest = "Output_folder"
 
@@ -168,25 +170,35 @@ class TestExtract(TestCase):
             [],
             [("jpg", 1)],
             [("jpg", 3), ("gif", 2), ("mp4", 1)],
+            [("png", 1)],
+            [("jpg", 2)],
         ]
 
         extract(src=src, dest=dest, log=True)
 
-        self.assertEqual(3, mock_check_valid_file.call_count)
-        self.assertEqual(3, mock_get_media_list.call_count)
-        self.assertEqual(3, mock_extract_media.call_count)
-        self.assertEqual(3, mock_zip_file.call_count)
-        self.assertEqual(("Test.pptx", "r"), mock_zip_file.call_args[0])
+        self.assertEqual(5, mock_check_valid_file.call_count)
+        self.assertEqual(5, mock_get_media_list.call_count)
+        self.assertEqual(5, mock_extract_media.call_count)
+        self.assertEqual(5, mock_zip_file.call_count)
+        self.assertEqual(
+            ("some", "other", "folder3", "Test3.xlsx"),
+            mock_zip_file.call_args[0][0].parts,
+        )
+        self.assertEqual("r", mock_zip_file.call_args[0][1])
 
         # Test print() to sys.stdout
         expected = (
-            "\nNo media files found in my/folder/Test.docx.",
-            "\n1 media file extracted from my/other/folder/Test.xlsx:",
+            f"\nNo media files found in {Path('some/folder/Test.docx')}.",
+            f"\n1 media file extracted from {Path('some/other/folder/Test.xlsx')}:",
             "- 1 jpg",
             "\n6 media files extracted from Test.pptx:",
             "- 3 jpg",
             "- 2 gif",
             "- 1 mp4",
+            f"\n1 media file extracted from {Path('some/other/folder2/Test2.xlsx')}:",
+            "- 1 png",
+            f"\n2 media files extracted from {Path('some/other/folder3/Test3.xlsx')}:",
+            "- 2 jpg",
         )
 
         for expected_calls, actual_calls in zip(expected, mock_print.call_args_list):

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -180,24 +180,21 @@ class TestExtract(TestCase):
         self.assertEqual(5, mock_get_media_list.call_count)
         self.assertEqual(5, mock_extract_media.call_count)
         self.assertEqual(5, mock_zip_file.call_count)
-        self.assertEqual(
-            ("some", "other", "folder3", "Test3.xlsx"),
-            mock_zip_file.call_args[0][0].parts,
-        )
+        self.assertEqual(Path(src[-1]), mock_zip_file.call_args[0][0])
         self.assertEqual("r", mock_zip_file.call_args[0][1])
 
         # Test print() to sys.stdout
         expected = (
-            f"\nNo media files found in {Path('some/folder/Test.docx')}.",
-            f"\n1 media file extracted from {Path('some/other/folder/Test.xlsx')}:",
+            f"\nNo media files found in {Path(src[0])}.",
+            f"\n1 media file extracted from {Path(src[1])}:",
             "- 1 jpg",
             "\n6 media files extracted from Test.pptx:",
             "- 3 jpg",
             "- 2 gif",
             "- 1 mp4",
-            f"\n1 media file extracted from {Path('some/other/folder2/Test2.xlsx')}:",
+            f"\n1 media file extracted from {Path(src[3])}:",
             "- 1 png",
-            f"\n2 media files extracted from {Path('some/other/folder3/Test3.xlsx')}:",
+            f"\n2 media files extracted from {Path(src[4])}:",
             "- 2 jpg",
         )
 


### PR DESCRIPTION
Fixed an issue with paths under Windows. Now `r"\"` and `"\\"` should as well work.