### PR TITLE
Fixed parent directory of source file as output directory

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -69,6 +69,7 @@ Release Notes
 
     * Fixed a typo in the PyPI badges in README.md
     * Fixed an issue with paths under Windows. ``r"\"`` and ``"\\"`` are now working as expected.
+    * The output directory can now be the parent directory of the source file. E.g. ``officeextractor.extract(src="some/folder/file.docx", dest="some/folder")``. The output subdirectories are now created with ``Extract_`` as prefix. E.g. ``Extracted_file.docx``
 
     **⚠️ Deprecation**
 

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -69,7 +69,7 @@ Release Notes
 
     * Fixed a typo in the PyPI badges in README.md
     * Fixed an issue with paths under Windows. ``r"\"`` and ``"\\"`` are now working as expected.
-    * The output directory can now be the parent directory of the source file. E.g. ``officeextractor.extract(src="some/folder/file.docx", dest="some/folder")``. The output subdirectories are now created with ``Extract_`` as prefix. E.g. ``Extracted_file.docx``
+    * The output directory can now be the parent directory of the source file. E.g. ``officeextractor.extract(src="some/folder/file.docx", dest="some/folder")``. The output subdirectories are now created with ``Extract_`` as prefix. E.g. ``some/folder/Extracted_file.docx``
 
     **⚠️ Deprecation**
 

--- a/officeextractor/main.py
+++ b/officeextractor/main.py
@@ -77,7 +77,7 @@ def extract(
         file_name_path = Path(file_name)
         check_valid_file(file_name_path)  # Check if the file is valid
         # Create subfolder Path object
-        output_folder = Path.joinpath(dest_path, file_name_path.name)
+        output_folder = Path.joinpath(dest_path, "Extracted_" + file_name_path.name)
         # Do the actual extraction
         with ZipFile(file_name_path, "r") as zip_file:
             media_list = get_media_list(zip_file=zip_file)


### PR DESCRIPTION
The output directory can now be the parent directory of the source file.

E.g. ``officeextractor.extract(src="some/folder/file.docx", dest="some/folder")``.

To make this possible, the output sub-directories are now created with ``Extract_`` as prefix. E.g. ``some/folder/Extracted_file.docx``